### PR TITLE
Polish Medium feed generator

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type RSS struct {
@@ -25,228 +26,240 @@ type Item struct {
 	PubDate string `xml:"pubDate"`
 }
 
-const maxTitleLength = 65 // Set the maximum title length for display
+type FeedEntry struct {
+	Title   string
+	GUID    string
+	PubDate string
+	Feeds   []FeedLink
+	IsNew   bool
+	IsToday bool
+}
+
+type FeedLink struct {
+	Name string
+	URL  string
+}
+
+const maxTitleLength = 65
 const mediumFeedPath = "writeups/medium-feed.md"
+const freediumMirrorBase = "https://freedium-mirror.cfd/"
 
 var httpClient = &http.Client{
 	Timeout: 20 * time.Second,
 }
 
-func fetchRSSFeed(url string) (*RSS, error) {
-	// Fetch the RSS feed
-	resp, err := httpClient.Get(url)
+var feedURLs = []string{
+	"https://medium.com/feed/tag/bug-bounty",
+	"https://medium.com/feed/tag/security",
+	"https://medium.com/feed/tag/vulnerability",
+	"https://medium.com/feed/tag/cybersecurity",
+	"https://medium.com/feed/tag/penetration-testing",
+	"https://medium.com/feed/tag/hacking",
+	"https://medium.com/feed/tag/information-technology",
+	"https://medium.com/feed/tag/infosec",
+	"https://medium.com/feed/tag/web-security",
+	"https://medium.com/feed/tag/bug-bounty-tips",
+	"https://medium.com/feed/tag/bugs",
+	"https://medium.com/feed/tag/pentesting",
+	"https://medium.com/feed/tag/xss-attack",
+	"https://medium.com/feed/tag/information-security",
+	"https://medium.com/feed/tag/cross-site-scripting",
+	"https://medium.com/feed/tag/hackerone",
+	"https://medium.com/feed/tag/bugcrowd",
+	"https://medium.com/feed/tag/bugbounty-writeup",
+	"https://medium.com/feed/tag/bug-bounty-writeup",
+	"https://medium.com/feed/tag/bug-bounty-hunter",
+	"https://medium.com/feed/tag/bug-bounty-program",
+	"https://medium.com/feed/tag/ethical-hacking",
+	"https://medium.com/feed/tag/application-security",
+	"https://medium.com/feed/tag/google-dorking",
+	"https://medium.com/feed/tag/dorking",
+	"https://medium.com/feed/tag/cyber-security-awareness",
+	"https://medium.com/feed/tag/google-dork",
+	"https://medium.com/feed/tag/web-pentest",
+	"https://medium.com/feed/tag/vdp",
+	"https://medium.com/feed/tag/information-disclosure",
+	"https://medium.com/feed/tag/exploit",
+	"https://medium.com/feed/tag/vulnerability-disclosure",
+	"https://medium.com/feed/tag/web-cache-poisoning",
+	"https://medium.com/feed/tag/rce",
+	"https://medium.com/feed/tag/remote-code-execution",
+	"https://medium.com/feed/tag/local-file-inclusion",
+	"https://medium.com/feed/tag/vapt",
+	"https://medium.com/feed/tag/dorks",
+	"https://medium.com/feed/tag/github-dorking",
+	"https://medium.com/feed/tag/lfi",
+	"https://medium.com/feed/tag/vulnerability-scanning",
+	"https://medium.com/feed/tag/subdomain-enumeration",
+	"https://medium.com/feed/tag/cybersecurity-tools",
+	"https://medium.com/feed/tag/bug-bounty-hunting",
+	"https://medium.com/feed/tag/ssrf",
+	"https://medium.com/feed/tag/idor",
+	"https://medium.com/feed/tag/pentest",
+	"https://medium.com/feed/tag/file-upload",
+	"https://medium.com/feed/tag/file-inclusion",
+	"https://medium.com/feed/tag/security-research",
+	"https://medium.com/feed/tag/directory-listing",
+	"https://medium.com/feed/tag/log-poisoning",
+	"https://medium.com/feed/tag/cve",
+	"https://medium.com/feed/tag/xss-vulnerability",
+	"https://medium.com/feed/tag/shodan",
+	"https://medium.com/feed/tag/censys",
+	"https://medium.com/feed/tag/zoomeye",
+	"https://medium.com/feed/tag/recon",
+	"https://medium.com/feed/tag/xss-bypass",
+	"https://medium.com/feed/tag/bounty-program",
+	"https://medium.com/feed/tag/subdomain-takeover",
+	"https://medium.com/feed/tag/bounties",
+	"https://medium.com/feed/tag/api-key",
+	"https://medium.com/feed/tag/cyber-sec",
+}
+
+func fetchRSSFeed(feedURL string) (*RSS, error) {
+	resp, err := httpClient.Get(feedURL)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching URL %s: %v", url, err)
+		return nil, fmt.Errorf("fetch %s: %w", feedURL, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("non-2xx response from %s: %s", url, resp.Status)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("fetch %s: unexpected status %s", feedURL, resp.Status)
 	}
 
-	// Read the RSS feed
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("error reading response body from %s: %v", url, err)
+		return nil, fmt.Errorf("read %s: %w", feedURL, err)
 	}
 
-	// Parse the RSS feed
 	var rss RSS
-	err = xml.Unmarshal(data, &rss)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing XML from %s: %v", url, err)
+	if err := xml.Unmarshal(data, &rss); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", feedURL, err)
 	}
 
 	return &rss, nil
 }
 
 func main() {
-	// List of RSS feed URLs
-	urls := []string{
-		"https://medium.com/feed/tag/bug-bounty",
-		"https://medium.com/feed/tag/security",
-		"https://medium.com/feed/tag/vulnerability",
-		"https://medium.com/feed/tag/cybersecurity",
-		"https://medium.com/feed/tag/penetration-testing",
-		"https://medium.com/feed/tag/hacking",
-		"https://medium.com/feed/tag/information-technology",
-		"https://medium.com/feed/tag/infosec",
-		"https://medium.com/feed/tag/web-security",
-		"https://medium.com/feed/tag/bug-bounty-tips",
-		"https://medium.com/feed/tag/bugs",
-		"https://medium.com/feed/tag/pentesting",
-		"https://medium.com/feed/tag/xss-attack",
-		"https://medium.com/feed/tag/information-security",
-		"https://medium.com/feed/tag/cross-site-scripting",
-		"https://medium.com/feed/tag/hackerone",
-		"https://medium.com/feed/tag/bugcrowd",
-		"https://medium.com/feed/tag/bugbounty-writeup",
-		"https://medium.com/feed/tag/bug-bounty-writeup",
-		"https://medium.com/feed/tag/bug-bounty-hunter",
-		"https://medium.com/feed/tag/bug-bounty-program",
-		"https://medium.com/feed/tag/ethical-hacking",
-		"https://medium.com/feed/tag/application-security",
-		"https://medium.com/feed/tag/google-dorking",
-		"https://medium.com/feed/tag/dorking",
-		"https://medium.com/feed/tag/cyber-security-awareness",
-		"https://medium.com/feed/tag/google-dork",
-		"https://medium.com/feed/tag/web-pentest",
-		"https://medium.com/feed/tag/vdp",
-		"https://medium.com/feed/tag/information-disclosure",
-		"https://medium.com/feed/tag/exploit",
-		"https://medium.com/feed/tag/vulnerability-disclosure",
-		"https://medium.com/feed/tag/web-cache-poisoning",
-		"https://medium.com/feed/tag/rce",
-		"https://medium.com/feed/tag/remote-code-execution",
-		"https://medium.com/feed/tag/local-file-inclusion",
-		"https://medium.com/feed/tag/vapt",
-		"https://medium.com/feed/tag/dorks",
-		"https://medium.com/feed/tag/github-dorking",
-		"https://medium.com/feed/tag/lfi",
-		"https://medium.com/feed/tag/vulnerability-scanning",
-		"https://medium.com/feed/tag/subdomain-enumeration",
-		"https://medium.com/feed/tag/cybersecurity-tools",
-		"https://medium.com/feed/tag/bug-bounty-hunting",
-		"https://medium.com/feed/tag/ssrf",
-		"https://medium.com/feed/tag/idor",
-		"https://medium.com/feed/tag/pentest",
-		"https://medium.com/feed/tag/file-upload",
-		"https://medium.com/feed/tag/file-inclusion",
-		"https://medium.com/feed/tag/security-research",
-		"https://medium.com/feed/tag/directory-listing",
-		"https://medium.com/feed/tag/log-poisoning",
-		"https://medium.com/feed/tag/cve",
-		"https://medium.com/feed/tag/xss-vulnerability",
-		"https://medium.com/feed/tag/shodan",
-		"https://medium.com/feed/tag/censys",
-		"https://medium.com/feed/tag/zoomeye",
-		"https://medium.com/feed/tag/recon",
-		"https://medium.com/feed/tag/xss-bypass",
-		"https://medium.com/feed/tag/bounty-program",
-		"https://medium.com/feed/tag/subdomain-takeover",
-		"https://medium.com/feed/tag/bounties",
-		"https://medium.com/feed/tag/api-key",
-		"https://medium.com/feed/tag/cyber-sec",
-	}
-
-	// Read the current generated Medium feed, if it exists.
-	readmeContent, err := os.ReadFile(mediumFeedPath)
+	existingFeed, err := os.ReadFile(mediumFeedPath)
 	if err != nil && !os.IsNotExist(err) {
-		fmt.Printf("Error reading %s: %v\n", mediumFeedPath, err)
-		return
+		fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", mediumFeedPath, err)
+		os.Exit(1)
 	}
-	readmeText := string(readmeContent)
 
-	// Get the current date in GMT
-	currentDate := time.Now().In(time.UTC).Format("Mon, 02 Jan 2006")
+	existingFeedText := string(existingFeed)
+	currentDate := time.Now().UTC().Format("Mon, 02 Jan 2006")
+	entries := make(map[string]*FeedEntry)
 
-	// A map to track GUIDs and their associated feed tags
-	entries := make(map[string]map[string]string)
-
-	for _, url := range urls {
-		// Fetch and parse each feed
-		rss, err := fetchRSSFeed(url)
+	for _, feedURL := range feedURLs {
+		rss, err := fetchRSSFeed(feedURL)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			continue
 		}
 
-		feedName := extractFeedName(url) // Function to get the feed name from the URL
-
-		// Process each feed item
+		feedLink := FeedLink{Name: extractFeedName(feedURL), URL: feedURL}
 		for _, item := range rss.Channel.Items {
-			if _, found := entries[item.GUID]; !found {
-				// Initialize entry if not already in the map
-				entries[item.GUID] = map[string]string{
-					"title":   item.Title,
-					"guid":    item.GUID,
-					"pubDate": item.PubDate,
-					"feeds":   fmt.Sprintf("[%s](%s)", feedName, url),
-					"isNew":   "Yes",
-					"isToday": isToday(item.PubDate, currentDate),
-				}
-
-				// Check if the item already exists in README.md
-				if strings.Contains(readmeText, item.GUID) {
-					entries[item.GUID]["isNew"] = ""
-				}
-			} else {
-				// If GUID already exists, append the new feed tag
-				existingFeeds := entries[item.GUID]["feeds"]
-				entries[item.GUID]["feeds"] = existingFeeds + fmt.Sprintf(", [%s](%s)", feedName, url)
+			guid := strings.TrimSpace(item.GUID)
+			if guid == "" {
+				continue
 			}
+			entry, found := entries[guid]
+			if !found {
+				entry = &FeedEntry{
+					Title:   item.Title,
+					GUID:    guid,
+					PubDate: item.PubDate,
+					IsNew:   !strings.Contains(existingFeedText, guid),
+					IsToday: isToday(item.PubDate, currentDate),
+				}
+				entries[guid] = entry
+			}
+			entry.Feeds = append(entry.Feeds, feedLink)
 		}
 
-		// Sleep for 3 seconds before fetching the next URL
 		time.Sleep(3 * time.Second)
 	}
 
-	// Convert the entries map to a slice for sorting
-	entryList := make([]map[string]string, 0, len(entries))
+	entryList := make([]*FeedEntry, 0, len(entries))
 	for _, entry := range entries {
 		entryList = append(entryList, entry)
 	}
 
-	// Sort entries: prioritize "Yes" for `IsNew`, then "Yes" for `IsToday`
 	sort.SliceStable(entryList, func(i, j int) bool {
-		if entryList[i]["isNew"] == entryList[j]["isNew"] {
-			return entryList[i]["isToday"] > entryList[j]["isToday"]
+		if entryList[i].IsNew != entryList[j].IsNew {
+			return entryList[i].IsNew
 		}
-		return entryList[i]["isNew"] > entryList[j]["isNew"]
+		if entryList[i].IsToday != entryList[j].IsToday {
+			return entryList[i].IsToday
+		}
+		return entryList[i].PubDate > entryList[j].PubDate
 	})
 
-	// Print the table header
 	fmt.Println("| Time | Title | Feed | IsNew | IsToday |")
 	fmt.Println("|-----------|-----|-----|-----|-----|")
-
-	// Print the sorted entries
 	for _, entry := range entryList {
-		// Sanitize and format the title
-		title := sanitizeTitle(entry["title"])
-
-		fmt.Printf("| %s | [%s](https://freedium-mirror.cfd/%s) | %s | %s | %s |\n",
-			entry["pubDate"], title, entry["guid"], entry["feeds"], entry["isNew"], entry["isToday"])
+		fmt.Printf("| %s | [%s](%s%s) | %s | %s | %s |\n",
+			entry.PubDate,
+			sanitizeTitle(entry.Title),
+			freediumMirrorBase,
+			markdownURLPath(entry.GUID),
+			formatFeedLinks(entry.Feeds),
+			formatYes(entry.IsNew),
+			formatYes(entry.IsToday),
+		)
 	}
 }
 
-// Helper function to extract the feed name from the URL
-func extractFeedName(url string) string {
-	parts := strings.Split(url, "/")
+func markdownURLPath(value string) string {
+	value = strings.ReplaceAll(value, " ", "%20")
+	value = strings.ReplaceAll(value, ")", "%29")
+	return strings.ReplaceAll(value, "\n", "")
+}
+
+func extractFeedName(feedURL string) string {
+	parts := strings.Split(strings.TrimRight(feedURL, "/"), "/")
 	return parts[len(parts)-1]
 }
 
-// Helper function to sanitize the title (limit length and escape special characters)
 func sanitizeTitle(title string) string {
-	// Remove newline and carriage return characters
-	title = strings.ReplaceAll(title, "\n", " ")
-	title = strings.ReplaceAll(title, "\r", " ")
-
-	// Escape brackets inside the title to prevent issues in Markdown links
+	title = strings.Join(strings.Fields(title), " ")
 	title = strings.ReplaceAll(title, "|", "\\|")
 	title = strings.ReplaceAll(title, "[", "\\[")
 	title = strings.ReplaceAll(title, "]", "\\]")
 
-	// Trim the title if it exceeds max length
-	if len(title) > maxTitleLength {
-		title = title[:maxTitleLength] + "..."
+	if utf8.RuneCountInString(title) > maxTitleLength {
+		runes := []rune(title)
+		title = string(runes[:maxTitleLength]) + "..."
 	}
 
 	return title
 }
 
-// Helper function to check if the PubDate matches the current date
-func isToday(pubDate, currentDate string) string {
-	// Parse the pubDate
+func isToday(pubDate, currentDate string) bool {
 	pubTime, err := time.Parse(time.RFC1123, pubDate)
 	if err != nil {
-		fmt.Printf("Error parsing date %s: %v\n", pubDate, err)
-		return ""
+		fmt.Fprintf(os.Stderr, "Error parsing date %s: %v\n", pubDate, err)
+		return false
 	}
 
-	// Format the parsed time to match the current date format
-	pubDateFormatted := pubTime.Format("Mon, 02 Jan 2006")
+	return pubTime.UTC().Format("Mon, 02 Jan 2006") == currentDate
+}
 
-	// Return "Yes" if pubDate is today, otherwise return an empty string
-	if pubDateFormatted == currentDate {
+func formatFeedLinks(feeds []FeedLink) string {
+	links := make([]string, 0, len(feeds))
+	seen := make(map[string]bool, len(feeds))
+	for _, feed := range feeds {
+		key := feed.Name + "\x00" + feed.URL
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		links = append(links, fmt.Sprintf("[%s](%s)", feed.Name, feed.URL))
+	}
+	return strings.Join(links, ", ")
+}
+
+func formatYes(value bool) string {
+	if value {
 		return "Yes"
 	}
 	return ""

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func TestSanitizeTitle(t *testing.T) {
+	got := sanitizeTitle("hello\n[bug] | café")
+	want := "hello \\[bug\\] \\| café"
+	if got != want {
+		t.Fatalf("sanitizeTitle() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeTitleTruncatesRunes(t *testing.T) {
+	got := sanitizeTitle("012345678901234567890123456789012345678901234567890123456789😀abcdef")
+	if len([]rune(got)) != maxTitleLength+3 {
+		t.Fatalf("sanitizeTitle() rune length = %d, want %d", len([]rune(got)), maxTitleLength+3)
+	}
+	if got[len(got)-3:] != "..." {
+		t.Fatalf("sanitizeTitle() = %q, want ellipsis suffix", got)
+	}
+}
+
+func TestFormatFeedLinksDeduplicates(t *testing.T) {
+	feeds := []FeedLink{
+		{Name: "bug-bounty", URL: "https://medium.com/feed/tag/bug-bounty"},
+		{Name: "bug-bounty", URL: "https://medium.com/feed/tag/bug-bounty"},
+		{Name: "security", URL: "https://medium.com/feed/tag/security"},
+	}
+	got := formatFeedLinks(feeds)
+	want := "[bug-bounty](https://medium.com/feed/tag/bug-bounty), [security](https://medium.com/feed/tag/security)"
+	if got != want {
+		t.Fatalf("formatFeedLinks() = %q, want %q", got, want)
+	}
+}
+
+func TestMarkdownURLPath(t *testing.T) {
+	got := markdownURLPath("https://medium.com/a title)\n")
+	want := "https://medium.com/a%20title%29"
+	if got != want {
+		t.Fatalf("markdownURLPath() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
### Motivation
- Make the Medium RSS feed generator more maintainable by replacing stringly-typed maps with typed structs and clearer data flow.
- Improve robustness for production runs by tightening HTTP/parse error handling and emitting operational errors to stderr.
- Ensure generated Markdown is safe and readable by normalizing titles, handling Unicode truncation correctly, and encoding URL path fragments used in links.
- Add unit tests to prevent regressions in title sanitization, link formatting, and URL path handling.

### Description
- Refactor `main.go` to introduce `FeedEntry` and `FeedLink` structs and move the feed list into a `feedURLs` slice; adjust logic to build and sort a typed `entryList` (new/Today/date priority) instead of map[string]map.
- Harden RSS fetching and parsing with wrapped errors, proper HTTP status checks, and writing operational errors to `stderr` via `fmt.Fprintln(os.Stderr, ...)` for visibility.
- Sanitize output for Markdown: add `sanitizeTitle` improvements (whitespace normalization, escape `[ ]` and `|`, Unicode-safe rune truncation using `unicode/utf8`), add `markdownURLPath` to percent-encode spaces and parentheses for freedium mirror links, and add `formatFeedLinks` to de-duplicate and format feed link list.
- Add unit tests in `main_test.go` covering `sanitizeTitle`, rune-safe truncation, `formatFeedLinks` de-duplication, and `markdownURLPath` behavior.

### Testing
- Ran `go test ./...` and tests passed (`ok  github.com/kdairatchi/medium-writeups`), confirming the new unit tests succeed.
- Ran `python3 -m py_compile scripts/sync_library.py` and it compiled successfully, confirming the existing sync script remains valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca11ff9108328ab74445cae66401c)